### PR TITLE
use 'next' in query string instead of session for login redirect

### DIFF
--- a/flaskeddit/auth/routes.py
+++ b/flaskeddit/auth/routes.py
@@ -1,4 +1,4 @@
-from flask import flash, redirect, render_template, session, url_for
+from flask import flash, redirect, render_template, request, url_for
 from flask_login import current_user, login_required
 
 from flaskeddit.auth import auth_blueprint, auth_service
@@ -36,9 +36,10 @@ def login():
         )
         if login_successful:
             flash("Successfully logged in.", "primary")
-            if session.get("next"):
-                return redirect(session.get("next"))
-            return redirect(url_for("feed.feed"))
+            next_location = request.args.get("next")
+            if next_location is None or not next_location.startswith("/"):
+                next_location = url_for("feed.feed")
+            return redirect(next_location)
         else:
             flash("Login Failed", "danger")
             return redirect(url_for("auth.login"))

--- a/flaskeddit/config.py
+++ b/flaskeddit/config.py
@@ -7,4 +7,3 @@ class Config:
     SECRET_KEY = os.environ.get("SECRET_KEY", os.urandom(16))
     SQLALCHEMY_DATABASE_URI = os.environ.get("DATABASE_URL", "sqlite:///app.db")
     SQLALCHEMY_TRACK_MODIFICATIONS = False
-    USE_SESSION_FOR_NEXT = True

--- a/flaskeddit/templates/login.jinja2
+++ b/flaskeddit/templates/login.jinja2
@@ -1,6 +1,6 @@
 {% extends "layout.jinja2" %} {% block content %}
 <h2 class="mb-3">Log In</h2>
-<form action="{{ url_for('auth.login') }}" method="POST">
+<form method="POST">
   {{ form.csrf_token }}
   <div class="form-group">
     {{ form.username.label }}


### PR DESCRIPTION
Switch to using `next` in the url query string instead of setting the value in the session. This is because if we store `next` in the session, the user may navigate to another page but when they login later, they will be directed to the `next` location value still stored in the session.