### PR TITLE
Update Configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,14 @@
+# OS
 .DS_Store
+
+# Editor
 .vscode/
+
+# Python
 venv/
 __pycache__/
-app.db
 .pytest_cache
+
+# DB
+app.db
+test.db

--- a/flaskeddit/config.py
+++ b/flaskeddit/config.py
@@ -4,6 +4,6 @@ import os
 class Config:
     """Configuration settings for the Flaskeddit Flask app."""
 
-    SECRET_KEY = os.environ.get("SECRET_KEY", os.urandom(16))
+    SECRET_KEY = os.environ.get("SECRET_KEY", "placeholder-secret-key")
     SQLALCHEMY_DATABASE_URI = os.environ.get("DATABASE_URL", "sqlite:///app.db")
     SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/flaskeddit/templates/layout.jinja2
+++ b/flaskeddit/templates/layout.jinja2
@@ -133,7 +133,7 @@
             <p>
               Made with <span class="text-danger">&#9829;</span> by aqche.
               <a
-                href="https://github.com/aqche"
+                href="https://github.com/aqche/flaskeddit"
                 target="_blank"
                 class="text-dark is-link"
                 ><i class="fab fa-github"></i

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -10,6 +10,7 @@ def test_client():
     """
     app = create_app()
     app.app_context().push()
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///test.db"
     app.config["WTF_CSRF_ENABLED"] = False
     db.create_all()
     yield app.test_client()


### PR DESCRIPTION
- Updates the `SECRET_KEY` config's default from `os.urandom(16)` to a placeholder string so sessions are not lost during app restarts when developing locally.
- Sets a separate `SQLALCHEMY_DATABASE_URI` for testing.
- Small reorganization of `.gitignore` file.
- Update footer to link to this repo.